### PR TITLE
Fix MSVC "redefinition; different storage class" build error

### DIFF
--- a/include/fpm/fixed.hpp
+++ b/include/fpm/fixed.hpp
@@ -379,7 +379,7 @@ struct numeric_limits<fpm::fixed<B,I,F>>
     static constexpr int digits10 = 1;
 
     // This is equal to max_digits10 for the integer and fractional part together.
-    static const int max_digits10 =
+    static constexpr int max_digits10 =
         fpm::detail::max_digits10(std::numeric_limits<B>::digits - F) + fpm::detail::max_digits10(F);
 
     static constexpr int radix = 2;


### PR DESCRIPTION
'max_digits10' is defined and declared with different constant specifiers, leads to compilation failures on MSVC 2019.

Thanks for the library, it's very cool! :)