### PR TITLE
Fix multiple warnings

### DIFF
--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -18,7 +18,6 @@ template <typename CharT, typename B, typename I, unsigned int F>
 std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I, F> x) noexcept
 {
     const auto uppercase = ((os.flags() & std::ios_base::uppercase) != 0);
-    // const auto showbase = ((os.flags() & std::ios_base::showbase) != 0); // Unused
     const auto showpoint = ((os.flags() & std::ios_base::showpoint) != 0);
     const auto adjustfield = (os.flags() & std::ios_base::adjustfield);
     const auto width = os.width();
@@ -677,7 +676,6 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
     constexpr auto MaxValue = (I{1} << sizeof(B) * 8) - 1;
 
     // Parse the integer part
-    // bool significand_overflow = false; // Never used
     I integer = 0;
     for (std::size_t i = 0; i < fraction_start; ++i) {
         if (integer > MaxInt / base) {

--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -18,7 +18,7 @@ template <typename CharT, typename B, typename I, unsigned int F>
 std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I, F> x) noexcept
 {
     const auto uppercase = ((os.flags() & std::ios_base::uppercase) != 0);
-    const auto showbase = ((os.flags() & std::ios_base::showbase) != 0);
+    // const auto showbase = ((os.flags() & std::ios_base::showbase) != 0); // Unused
     const auto showpoint = ((os.flags() & std::ios_base::showpoint) != 0);
     const auto adjustfield = (os.flags() & std::ios_base::adjustfield);
     const auto width = os.width();
@@ -126,7 +126,7 @@ std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I,
         // Fixed mode. Nothing to do.
         break;
 
-    case 0:
+    default:
     {
         // "auto" mode: figure out the exponent
         const number_t sci_value = as_scientific(value);
@@ -677,7 +677,7 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
     constexpr auto MaxValue = (I{1} << sizeof(B) * 8) - 1;
 
     // Parse the integer part
-    bool significand_overflow = false;
+    // bool significand_overflow = false; // Never used
     I integer = 0;
     for (std::size_t i = 0; i < fraction_start; ++i) {
         if (integer > MaxInt / base) {

--- a/include/fpm/math.hpp
+++ b/include/fpm/math.hpp
@@ -542,8 +542,6 @@ inline fixed<B, I, F> cos(fixed<B, I, F> x) noexcept
 template <typename B, typename I, unsigned int F>
 inline fixed<B, I, F> tan(fixed<B, I, F> x) noexcept
 {
-    // using Fixed = fixed<B, I, F>; // Unused
-
     auto cx = cos(x);
 
     // Tangent goes to infinity at 90 and -90 degrees.

--- a/include/fpm/math.hpp
+++ b/include/fpm/math.hpp
@@ -542,7 +542,7 @@ inline fixed<B, I, F> cos(fixed<B, I, F> x) noexcept
 template <typename B, typename I, unsigned int F>
 inline fixed<B, I, F> tan(fixed<B, I, F> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    // using Fixed = fixed<B, I, F>; // Unused
 
     auto cx = cos(x);
 


### PR DESCRIPTION
Hi,
I commented some unused variables and local typedef (which for some reason default configured PlatformIO treats as error, when they are needed they can be always brought back) 

I guess that the `0` in the `switch` is supposed to work as a sanity check, but is it necessary? Again it got treated as an error for me, so that's why I replaced it with `default`, which also removed the warnings about missing `enum` members because the `auto` treated them as such.