### PR TITLE
fix: fix VS 2019 build by upgrading CNL dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ set(LIBCNL_ROOT "${CMAKE_CURRENT_BINARY_DIR}/libcnl")
 
 ExternalProject_Add(libcnl-external
   GIT_REPOSITORY "https://github.com/johnmcfarlane/cnl"
-  GIT_TAG d6df27818fbc7f6de17af60e0cacae8443592c93
+  GIT_TAG 4d445566fe7c6c8939fffc145a2f30fd587796a6
   PREFIX ${LIBCNL_ROOT}
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
CNL contained a conversion function with trailing return type. VS 2019 does not like that. This problem has been fixed in CNLs, so this upgrades CNLfrom pre-v0.0.6 to v1.1.2.