### PR TITLE
fix: fix C++11 violation in fpm/ios.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ add_executable(fpm-test
   tests/power.cpp
   tests/trigonometry.cpp
 )
-set_target_properties(fpm-test PROPERTIES CXX_STANDARD 14)
+set_target_properties(fpm-test PROPERTIES CXX_STANDARD 11)
 target_link_libraries(fpm-test PRIVATE fpm gtest_main)
 gtest_add_tests(TARGET fpm-test)
 

--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -642,7 +642,7 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
     // We've parsed all we need. Construct the value.
     if (exponent_overflow) {
         // Absolute exponent is too large
-        if (std::all_of(significand.begin(), significand.end(), [](auto x){ return x == 0; })) {
+        if (std::all_of(significand.begin(), significand.end(), [](unsigned char x){ return x == 0; })) {
             // Significand is zero. Exponent doesn't matter.
             x = fixed<B, I, F>(0);
         } else if (exponent_negate) {

--- a/tests/customizations.cpp
+++ b/tests/customizations.cpp
@@ -51,8 +51,8 @@ struct Limits<fpm::fixed_16_16>
     static constexpr int max_exponent() noexcept { return  15; }
     static constexpr int min_exponent10() noexcept { return -4; }
     static constexpr int max_exponent10() noexcept { return 4; }
-    static constexpr auto min() noexcept { return fpm::fixed_16_16::from_raw_value(-2147483647 - 1); }
-    static constexpr auto max() noexcept { return fpm::fixed_16_16::from_raw_value( 2147483647); }
+    static constexpr fpm::fixed_16_16 min() noexcept { return fpm::fixed_16_16::from_raw_value(-2147483647 - 1); }
+    static constexpr fpm::fixed_16_16 max() noexcept { return fpm::fixed_16_16::from_raw_value( 2147483647); }
 };
 
 template <>
@@ -65,8 +65,8 @@ struct Limits<fpm::fixed_24_8>
     static constexpr int max_exponent() noexcept { return 23; }
     static constexpr int min_exponent10() noexcept { return -2; }
     static constexpr int max_exponent10() noexcept { return 6; }
-    static constexpr auto min() noexcept { return fpm::fixed_24_8::from_raw_value(-2147483647 - 1); }
-    static constexpr auto max() noexcept { return fpm::fixed_24_8::from_raw_value( 2147483647); }
+    static constexpr fpm::fixed_24_8 min() noexcept { return fpm::fixed_24_8::from_raw_value(-2147483647 - 1); }
+    static constexpr fpm::fixed_24_8 max() noexcept { return fpm::fixed_24_8::from_raw_value( 2147483647); }
 };
 
 template <>
@@ -79,8 +79,8 @@ struct Limits<fpm::fixed_8_24>
     static constexpr int max_exponent() noexcept { return  7; }
     static constexpr int min_exponent10() noexcept { return -7; }
     static constexpr int max_exponent10() noexcept { return  2; }
-    static constexpr auto min() noexcept { return fpm::fixed_8_24::from_raw_value(-2147483647 - 1); }
-    static constexpr auto max() noexcept { return fpm::fixed_8_24::from_raw_value( 2147483647); }
+    static constexpr fpm::fixed_8_24 min() noexcept { return fpm::fixed_8_24::from_raw_value(-2147483647 - 1); }
+    static constexpr fpm::fixed_8_24 max() noexcept { return fpm::fixed_8_24::from_raw_value( 2147483647); }
 };
 
 TYPED_TEST(customizations, numeric_limits)

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -106,20 +106,12 @@ private:
     std::stringstream create_stream() const
     {
         std::stringstream ss;
-        ss.setf(combine_or(GetParam(), std::make_index_sequence<4>{}));
+        ss.setf(std::get<0>(GetParam()) | std::get<1>(GetParam()) | std::get<2>(GetParam()) | std::get<3>(GetParam()));
         ss.precision(std::get<4>(GetParam()));
         ss.width(std::get<5>(GetParam()));
         ss.fill(std::get<6>(GetParam()));
         ss.imbue(std::get<7>(GetParam()));
         return ss;
-    }
-
-    template <std::size_t... I>
-    static fmtflags combine_or(const Flags& flags, std::index_sequence<I...>)
-    {
-        fmtflags result{};
-        std::make_tuple((result |= std::get<I>(flags))...);
-        return result;
     }
 };
 


### PR DESCRIPTION
`fpm` targets C++11 but `fpm/ios.h` used `auto` in a lambda, which is not allowed in C++11.
This went unnoticed because the tests were compiled in C++14 mode.

To fix this, and catch these issues in the future, the tests have been switched to C++11, which required a few small changes in them.

Fixes #11