### PR TITLE
fix: fix operator<< for values at the base type's negative limit

### DIFF
--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -57,8 +57,8 @@ std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I,
     // The value of the number is: raw / divisor * (10|2) ^ exponent
     // The base of the exponent is 2 in hexfloat mode, or 10 otherwise.
     struct number_t {
-        B raw;          // raw fixed-point value
-        B divisor;      // the divisor indicating the place of the decimal point
+        I raw;          // raw fixed-point value
+        I divisor;      // the divisor indicating the place of the decimal point
         int exponent;   // the exponent applied
     };
 
@@ -80,7 +80,7 @@ std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I,
         return value;
     };
 
-    number_t value = { x.raw_value(), B{1} << F, 0};
+    number_t value = { x.raw_value(), I{1} << F, 0};
 
     auto base = B{10};
 
@@ -106,7 +106,7 @@ std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I,
         {
             auto bit  = detail::find_highest_bit(value.raw);
             value.exponent = bit - F;    // exponent is applied to base 2
-            value.divisor = B{1} << bit; // divisor is at the highest bit, ensuring it starts with "1."
+            value.divisor = I{1} << bit; // divisor is at the highest bit, ensuring it starts with "1."
             precision = (bit + 3) / 4;   // precision is number of nibbles, so we show all of them
         }
         base = 16;
@@ -155,7 +155,7 @@ std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I,
     }
 
     // Separate out the integral part of the number
-    B integral = value.raw / value.divisor;
+    I integral = value.raw / value.divisor;
     value.raw %= value.divisor;
 
     // Here we start printing the number itself

--- a/include/fpm/math.hpp
+++ b/include/fpm/math.hpp
@@ -18,15 +18,23 @@ namespace detail
 {
 
 // Returns the index of the most-signifcant set bit
-inline long find_highest_bit(unsigned long value) noexcept
+inline long find_highest_bit(unsigned long long value) noexcept
 {
     assert(value != 0);
 #if defined(_MSC_VER)
     unsigned long index;
-    _BitScanReverse(&index, value);
+#if defined(_WIN64)
+    _BitScanReverse64(&index, value);
+#else
+    if (_BitScanReverse(&index, static_cast<unsigned long>(value >> 32)) != 0) {
+        index += 32;
+    } else {
+        _BitScanReverse(&index, static_cast<unsigned long>(value & 0xfffffffflu));
+    }
+#endif
     return index;
 #elif defined(__GNUC__) || defined(__clang__)
-    return sizeof(value) * 8 - 1 - __builtin_clzl(value);
+    return sizeof(value) * 8 - 1 - __builtin_clzll(value);
 #else
 #   error "your platform does not support find_highest_bit()"
 #endif

--- a/tests/output.cpp
+++ b/tests/output.cpp
@@ -305,3 +305,31 @@ TEST_F(output_rounding, scientific_rounding)
     test(0.09375, 0, std::ios::scientific);
     test(0.09375, 1, std::ios::scientific);
 }
+
+class output_specific : public ::testing::Test
+{
+protected:
+    template <typename Fixed>
+    void test(const char* expected, Fixed value, int precision, std::ios::fmtflags flags = std::ios::fixed)
+    {
+        std::stringstream ss;
+        ss << std::setiosflags(flags) << std::setprecision(precision) << value;
+        EXPECT_EQ(expected, ss.str());
+    }
+};
+
+TEST_F(output_specific, type_limit)
+{
+    using F4 = fpm::fixed<std::int8_t, std::int16_t, 4>;
+    using F16 = fpm::fixed_16_16;
+
+    test("-32768.000", F16::from_raw_value(-2147483647 - 1), 3, std::ios::fixed);
+    test("-3.277e+04", F16::from_raw_value(-2147483647 - 1), 3, std::ios::scientific);
+    test("32768.000", F16::from_raw_value(2147483647), 3, std::ios::fixed);
+    test("3.277e+04", F16::from_raw_value(2147483647), 3, std::ios::scientific);
+
+    test("-8.000", F4::from_raw_value(-127 - 1), 3, std::ios::fixed);
+    test("-8.000e+00", F4::from_raw_value(-127 - 1), 3, std::ios::scientific);
+    test("7.938", F4::from_raw_value(127), 3, std::ios::fixed);
+    test("7.938e+00", F4::from_raw_value(127), 3, std::ios::scientific);
+}


### PR DESCRIPTION
Outputting `fpm::fixed` where the internal representation is equal to the base type's negative limit (e.g. `INT32_MIN` for `fpm::fixed_16_16`) causes an assertion / overflow because of `value.raw = -value.raw`.

To avoid rewriting the formatting logic for negative numbers, the fix is to change the formatting to use the larger `IntermediateType` from the `fpm::fixed` type, instead of `BaseType`.

Fixes #14