### PR TITLE
fix: fix behavior of isnormal for zero input

### DIFF
--- a/include/fpm/math.hpp
+++ b/include/fpm/math.hpp
@@ -71,9 +71,9 @@ constexpr inline bool isnan(fixed<B, I, F>) noexcept
 }
 
 template <typename B, typename I, unsigned int F>
-constexpr inline bool isnormal(fixed<B, I, F>) noexcept
+constexpr inline bool isnormal(fixed<B, I, F> x) noexcept
 {
-    return true;
+    return x.raw_value() != 0;
 }
 
 template <typename B, typename I, unsigned int F>

--- a/tests/classification.cpp
+++ b/tests/classification.cpp
@@ -43,7 +43,7 @@ TEST(classification, isnormal)
     EXPECT_TRUE(isnormal(P(1.0)));
     EXPECT_TRUE(isnormal(P(-1.0)));
     EXPECT_TRUE(isnormal(P(0.5)));
-    EXPECT_TRUE(isnormal(P(0)));
+    EXPECT_FALSE(isnormal(P(0)));
 }
 
 TEST(classification, signbit)


### PR DESCRIPTION
0.0 is defined as not a normal number, but `isnormal(fixed{0.0})` returned true. This has been fixed.

Closes #24