### PR TITLE
fix: fix constexpr-ness of float-to-fixed constructor

### DIFF
--- a/include/fpm/fixed.hpp
+++ b/include/fpm/fixed.hpp
@@ -44,7 +44,7 @@ public:
     // Like static_cast, this truncates bits that don't fit.
     template <typename T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
     constexpr inline explicit fixed(T val) noexcept
-        : m_value(static_cast<BaseType>(std::round(val * FRACTION_MULT)))
+        : m_value(static_cast<BaseType>((val >= 0.0) ? (val * FRACTION_MULT + T{0.5}) : (val * FRACTION_MULT - T{0.5})))
     {}
 
     // Constructs from another fixed-point type with possibly different underlying representation.

--- a/tests/conversion.cpp
+++ b/tests/conversion.cpp
@@ -41,6 +41,17 @@ TEST(conversion, floats)
     EXPECT_EQ(1.125, static_cast<double>(P{1.125}));
 }
 
+TEST(conversion, float_rounding)
+{
+    // Small number of fraction bits to test rounding
+    using Q = fpm::fixed<std::int32_t, std::int64_t, 2>;
+
+    EXPECT_EQ(1.25, static_cast<double>(Q{1.125}));
+    EXPECT_EQ(1.5, static_cast<double>(Q{1.375}));
+    EXPECT_EQ(-1.25, static_cast<double>(Q{-1.125}));
+    EXPECT_EQ(-1.5, static_cast<double>(Q{-1.375}));
+}
+
 TEST(conversion, ints)
 {
     EXPECT_EQ(-125, static_cast<int>(P{-125}));


### PR DESCRIPTION
The constexpr `fpm::fixed` constructor taking a float used `std::round`, which is not a constexpr method, this causes a compilation failure on certain compilers.
This has been replaced with a manual rounding calculation, which is constexpr-safe.

Closes #26