### PR TITLE
Add support for PlatformIO

### DIFF
--- a/library.json
+++ b/library.json
@@ -13,9 +13,9 @@
     "url": "https://github.com/MikeLankamp/fpm.git"
   },
   "build": {
+    "srcFilter": "-<*> +<include/>",
     "includeDir": "include"
   },
-  "srcFilter": "-<*> +<include/>",
   "export": {
     "include": [
       "include",

--- a/library.json
+++ b/library.json
@@ -1,0 +1,27 @@
+{
+  "name": "fpm",
+  "version": "1.1.0",
+  "authors": {
+    "name": "Mike Lankamp",
+  },
+  "homepage": "https://mikelankamp.github.io/fpm/",
+  "license": "MIT",
+  "description": "A C++ header-only fixed-point math library.",
+  "keywords": "c-plus-plus, cpp, algorithms, numbers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MikeLankamp/fpm.git"
+  },
+  "build": {
+    "includeDir": "include"
+  },
+  "export": {
+    "include": [
+      "include",
+      "LICENSE",
+      "README.md"
+    ]
+  },
+  "platforms": "*",
+  "frameworks": "*"
+}

--- a/library.json
+++ b/library.json
@@ -2,7 +2,7 @@
   "name": "fpm",
   "version": "1.1.0",
   "authors": {
-    "name": "Mike Lankamp",
+    "name": "Mike Lankamp"
   },
   "homepage": "https://mikelankamp.github.io/fpm/",
   "license": "MIT",

--- a/library.json
+++ b/library.json
@@ -15,6 +15,7 @@
   "build": {
     "includeDir": "include"
   },
+  "srcFilter": "-<*> +<include/>",
   "export": {
     "include": [
       "include",


### PR DESCRIPTION
This file is needed to get this library to work seamlessly with PlatformIO. Docs for the file can be found at https://docs.platformio.org/en/latest/librarymanager/config.html

This has been tested with a platformio project by setting

```
lib_deps =
    https://github.com/flaviut/fpm.git#aa0a3aa265ea0733f3c6410785f31b53b0a0db03
```

and works fine.