### PR TITLE
Constructor of fpm::fixed should be "= default"

### DIFF
--- a/include/fpm/fixed.hpp
+++ b/include/fpm/fixed.hpp
@@ -31,7 +31,7 @@ class fixed
     constexpr inline fixed(BaseType val, raw_construct_tag) noexcept : m_value(val) {}
 
 public:
-    inline fixed() noexcept {}
+    inline fixed() noexcept = default;
 
     // Converts an integral number to the fixed-point type.
     // Like static_cast, this truncates bits that don't fit.


### PR DESCRIPTION
Currently, doing `fixed_16_16 f {};` does not initialize `f.m_value`. The expected behaviour is to do zero-initialization, like `int i{}` initializes `i` to `0`. The simple fix is to mark the constructor as default, which is good anyway.

Moreover, it can't be used in `constexpr` expressions:

```c++
constexpr void test()
{
    // fpm::fixed_16_16 f {}; // Error because can contain anything
    fpm::fixed_16_16 f{0}; // Ok
}
```

Also some of the operators like `+=` are not marked constexpr but that's another issue.