### PR TITLE
fix: broken conversion to float of types with maximum fraction bits

### DIFF
--- a/include/fpm/fixed.hpp
+++ b/include/fpm/fixed.hpp
@@ -20,12 +20,13 @@ class fixed
 {
     static_assert(std::is_integral<BaseType>::value, "BaseType must be an integral type");
     static_assert(FractionBits > 0, "FractionBits must be greater than zero");
-    static_assert(FractionBits <= sizeof(BaseType) * 8, "BaseType must at least be able to contain entire fraction");
-    static_assert(FractionBits <= 62, "Fraction may be no more than 62 bits");
+    static_assert(FractionBits <= sizeof(BaseType) * 8 - 1, "BaseType must at least be able to contain entire fraction, with space for at least one integral bit");
     static_assert(sizeof(IntermediateType) > sizeof(BaseType), "IntermediateType must be larger than BaseType");
     static_assert(std::is_signed<IntermediateType>::value == std::is_signed<BaseType>::value, "IntermediateType must have same signedness as BaseType");
 
-    static constexpr BaseType FRACTION_MULT = BaseType(1) << FractionBits;
+    // Although this value fits in the BaseType in terms of bits, if there's only one integral bit, this value
+    // is incorrect (flips from positive to negative), so we must extend the size to IntermediateType.
+    static constexpr IntermediateType FRACTION_MULT = IntermediateType(1) << FractionBits;
 
     struct raw_construct_tag {};
     constexpr inline fixed(BaseType val, raw_construct_tag) noexcept : m_value(val) {}

--- a/tests/customizations.cpp
+++ b/tests/customizations.cpp
@@ -119,3 +119,15 @@ TYPED_TEST(customizations, numeric_limits)
     EXPECT_EQ(L::round_error(), TypeParam(0.5));
     EXPECT_EQ(L::denorm_min(), TL::min());
 }
+
+// Verify that a a type with a single integral bit works correctly
+TEST(customizations, numeric_limits_edge)
+{
+    using Q15 = fpm::fixed<std::int16_t, std::int32_t, 15>;
+    EXPECT_TRUE(HasMaximumError(static_cast<double>(std::numeric_limits<Q15>::max()), 0.999, 0.01));
+    EXPECT_EQ(-1.0, static_cast<double>(std::numeric_limits<Q15>::lowest()));
+
+    using Q31 = fpm::fixed<std::int32_t, std::int64_t, 31>;
+    EXPECT_TRUE(HasMaximumError(static_cast<double>(std::numeric_limits<Q31>::max()), 0.999, 0.01));
+    EXPECT_EQ(-1.0, static_cast<double>(std::numeric_limits<Q31>::lowest()));
+}


### PR DESCRIPTION
Defining fixed-point types with a maximum number of fraction bits (e.g. Q1.15 or Q1.31) and converting their `max()` or `lowest()` to float resulted in incorrect values: the sign was flipped.

This was caused by the internal fraction multiplier not being representable in the (signed) base type for those number of fraction bits. Therefore its type was extended to the larger intermediate type.

Closes #33