### PR TITLE
feat: optionally disable rounding with template argument

### DIFF
--- a/tests/arithmetic.cpp
+++ b/tests/arithmetic.cpp
@@ -51,3 +51,27 @@ TEST(arithmethic, division_range)
     // wrong results without the intermediate type.
     EXPECT_EQ(P(32), P(256) / P(8));
 }
+
+TEST(arithmetic, multiplication_rounding)
+{
+    // Using 1 bit of fractional precision to test rounding
+    using Q_round = fpm::fixed<std::int32_t, std::int64_t, 1, true>;
+    using Q = fpm::fixed<std::int32_t, std::int64_t, 1, false>;
+
+    EXPECT_EQ(Q_round(1.0), Q_round(1.5) * Q_round(0.5));
+    EXPECT_EQ(Q_round(0.5), Q_round(0.5) * Q_round(0.5));
+    EXPECT_EQ(Q(0.5), Q(1.5) * Q(0.5));
+    EXPECT_EQ(Q(0.0), Q(0.5) * Q(0.5));
+}
+
+TEST(arithmetic, division_rounding)
+{
+    // Using 1 bit of fractional precision to test rounding
+    using Q_round = fpm::fixed<std::int32_t, std::int64_t, 1, true>;
+    using Q = fpm::fixed<std::int32_t, std::int64_t, 1, false>;
+
+    EXPECT_EQ(Q_round(2.5), Q_round(3.5) / Q_round(1.5));
+    EXPECT_EQ(Q_round(0.5), Q_round(1.0) / Q_round(1.5));
+    EXPECT_EQ(Q(2.0), Q(3.5) / Q(1.5));
+    EXPECT_EQ(Q(0.5), Q(1.0) / Q(1.5));
+}

--- a/tests/conversion.cpp
+++ b/tests/conversion.cpp
@@ -52,6 +52,19 @@ TEST(conversion, float_rounding)
     EXPECT_EQ(-1.5, static_cast<double>(Q{-1.375}));
 }
 
+TEST(conversion, float_no_rounding)
+{
+    // Small number of fraction bits to test no rounding
+    using Q = fpm::fixed<std::int32_t, std::int64_t, 2, false>;
+
+    EXPECT_EQ(1.0, static_cast<double>(Q{1.125}));
+    EXPECT_EQ(1.25, static_cast<double>(Q{1.375}));
+    EXPECT_EQ(1.25, static_cast<double>(Q{1.499}));
+    EXPECT_EQ(-1.0, static_cast<double>(Q{-1.125}));
+    EXPECT_EQ(-1.0, static_cast<double>(Q{-1.249}));
+    EXPECT_EQ(-1.25, static_cast<double>(Q{-1.375}));
+}
+
 TEST(conversion, ints)
 {
     EXPECT_EQ(-125, static_cast<int>(P{-125}));
@@ -74,6 +87,22 @@ TEST(conversion, fixed_point)
     // This should round up to 1
     EXPECT_EQ(P(-1), P::from_fixed_point<20>(-1048575));
     EXPECT_EQ(P(1), P::from_fixed_point<20>(1048575));
+}
+
+TEST(conversion, fixed_point_no_rounding)
+{
+    using P = fpm::fixed<std::int32_t, std::int64_t, 16, false>;
+    constexpr P epsilon = std::numeric_limits<P>::epsilon();
+
+    EXPECT_EQ(P(-1), P::from_fixed_point<0>(-1));
+    EXPECT_EQ(P(1), P::from_fixed_point<0>(1));
+
+    EXPECT_EQ(P(-1.125), P::from_fixed_point<4>(-18));
+    EXPECT_EQ(P(1.125), P::from_fixed_point<4>(18));
+
+    // This should NOT round up to 1: there will be a truncation error equal to epsilon
+    EXPECT_EQ(P(-1 + epsilon), P::from_fixed_point<20>(-1048575));
+    EXPECT_EQ(P(1 - epsilon), P::from_fixed_point<20>(1048575));
 }
 
 TEST(conversion, fixed_to_fixed)


### PR DESCRIPTION
This is a pull request for #48. 

This change should preserve backwards compatibility by defaulting `EnableRounding` to `true`. 
This pull request makes changes to and adds unit tests for the following:

- conversion from floating point
- conversion from fixed point type with larger fractional precision
- multiplication
- division
