### PR TITLE
feat: add support for non-rounding fixed point for math and io routines

### DIFF
--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -14,8 +14,8 @@
 namespace fpm
 {
 
-template <typename CharT, typename B, typename I, unsigned int F>
-std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I, F> x) noexcept
+template <typename CharT, typename B, typename I, unsigned int F, bool R>
+std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I, F, R> x) noexcept
 {
     const auto uppercase = ((os.flags() & std::ios_base::uppercase) != 0);
     const auto showpoint = ((os.flags() & std::ios_base::showpoint) != 0);
@@ -464,8 +464,8 @@ std::basic_ostream<CharT>& operator<<(std::basic_ostream<CharT>& os, fixed<B, I,
 }
 
 
-template <typename CharT, class Traits, typename B, typename I, unsigned int F>
-std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>& is, fixed<B, I, F>& x)
+template <typename CharT, class Traits, typename B, typename I, unsigned int F, bool R>
+std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>& is, fixed<B, I, F, R>& x)
 {
     typename std::basic_istream<CharT, Traits>::sentry sentry(is);
     if (!sentry)
@@ -545,7 +545,7 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
 
     if (i > 0) {
         if (i == 3 || i == 8) {
-            x = negate ? std::numeric_limits<fixed<B, I, F>>::min() : std::numeric_limits<fixed<B, I, F>>::max();
+            x = negate ? std::numeric_limits<fixed<B, I, F, R>>::min() : std::numeric_limits<fixed<B, I, F, R>>::max();
         } else {
             is.setstate(std::ios::failbit);
         }
@@ -644,13 +644,13 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
         // Absolute exponent is too large
         if (std::all_of(significand.begin(), significand.end(), [](unsigned char x){ return x == 0; })) {
             // Significand is zero. Exponent doesn't matter.
-            x = fixed<B, I, F>(0);
+            x = fixed<B, I, F, R>(0);
         } else if (exponent_negate) {
             // A huge negative exponent approaches 0.
-            x = fixed<B, I, F>::from_raw_value(0);
+            x = fixed<B, I, F, R>::from_raw_value(0);
         } else {
             // A huge positive exponent approaches infinity.
-            x = std::numeric_limits<fixed<B, I, F>>::max();
+            x = std::numeric_limits<fixed<B, I, F, R>>::max();
         }
         return is;
     }
@@ -680,7 +680,7 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
     for (std::size_t i = 0; i < fraction_start; ++i) {
         if (integer > MaxInt / base) {
             // Overflow
-            x = negate ? std::numeric_limits<fixed<B, I, F>>::min() : std::numeric_limits<fixed<B, I, F>>::max();
+            x = negate ? std::numeric_limits<fixed<B, I, F, R>>::min() : std::numeric_limits<fixed<B, I, F, R>>::max();
             return is;
         }
         assert(significand[i] < base);
@@ -724,14 +724,14 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
             for (std::size_t e = 0; e < exponent; ++e) {
                 if (raw_value > MaxValue / 10) {
                     // Overflow
-                    x = negate ? std::numeric_limits<fixed<B, I, F>>::min() : std::numeric_limits<fixed<B, I, F>>::max();
+                    x = negate ? std::numeric_limits<fixed<B, I, F, R>>::min() : std::numeric_limits<fixed<B, I, F, R>>::max();
                     return is;
                 }
                 raw_value *= 10;
             }
         }
     }
-    x = fixed<B, I, F>::from_raw_value(static_cast<B>(negate ? -raw_value : raw_value));
+    x = fixed<B, I, F, R>::from_raw_value(static_cast<B>(negate ? -raw_value : raw_value));
     return is;
 }
 

--- a/include/fpm/math.hpp
+++ b/include/fpm/math.hpp
@@ -46,74 +46,74 @@ inline long find_highest_bit(unsigned long long value) noexcept
 // Classification methods
 //
 
-template <typename B, typename I, unsigned int F>
-constexpr inline int fpclassify(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline int fpclassify(fixed<B, I, F, R> x) noexcept
 {
     return (x.raw_value() == 0) ? FP_ZERO : FP_NORMAL;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool isfinite(fixed<B, I, F>) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool isfinite(fixed<B, I, F, R>) noexcept
 {
     return true;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool isinf(fixed<B, I, F>) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool isinf(fixed<B, I, F, R>) noexcept
 {
     return false;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool isnan(fixed<B, I, F>) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool isnan(fixed<B, I, F, R>) noexcept
 {
     return false;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool isnormal(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool isnormal(fixed<B, I, F, R> x) noexcept
 {
     return x.raw_value() != 0;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool signbit(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool signbit(fixed<B, I, F, R> x) noexcept
 {
     return x.raw_value() < 0;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool isgreater(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool isgreater(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     return x > y;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool isgreaterequal(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool isgreaterequal(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     return x >= y;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool isless(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool isless(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     return x < y;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool islessequal(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool islessequal(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     return x <= y;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool islessgreater(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool islessgreater(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     return x != y;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline bool isunordered(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline bool isunordered(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     return false;
 }
@@ -121,41 +121,41 @@ constexpr inline bool isunordered(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
 //
 // Nearest integer operations
 //
-template <typename B, typename I, unsigned int F>
-inline fixed<B, I, F> ceil(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+inline fixed<B, I, F, R> ceil(fixed<B, I, F, R> x) noexcept
 {
     constexpr auto FRAC = B(1) << F;
     auto value = x.raw_value();
     if (value > 0) value += FRAC - 1;
-    return fixed<B, I, F>::from_raw_value(value / FRAC * FRAC);
+    return fixed<B, I, F, R>::from_raw_value(value / FRAC * FRAC);
 }
 
-template <typename B, typename I, unsigned int F>
-inline fixed<B, I, F> floor(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+inline fixed<B, I, F, R> floor(fixed<B, I, F, R> x) noexcept
 {
     constexpr auto FRAC = B(1) << F;
     auto value = x.raw_value();
     if (value < 0) value -= FRAC - 1;
-    return fixed<B, I, F>::from_raw_value(value / FRAC * FRAC);
+    return fixed<B, I, F, R>::from_raw_value(value / FRAC * FRAC);
 }
 
-template <typename B, typename I, unsigned int F>
-inline fixed<B, I, F> trunc(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+inline fixed<B, I, F, R> trunc(fixed<B, I, F, R> x) noexcept
 {
     constexpr auto FRAC = B(1) << F;
-    return fixed<B, I, F>::from_raw_value(x.raw_value() / FRAC * FRAC);
+    return fixed<B, I, F, R>::from_raw_value(x.raw_value() / FRAC * FRAC);
 }
 
-template <typename B, typename I, unsigned int F>
-inline fixed<B, I, F> round(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+inline fixed<B, I, F, R> round(fixed<B, I, F, R> x) noexcept
 {
     constexpr auto FRAC = B(1) << F;
     auto value = x.raw_value() / (FRAC / 2);
-    return fixed<B, I, F>::from_raw_value(((value / 2) + (value % 2)) * FRAC);
+    return fixed<B, I, F, R>::from_raw_value(((value / 2) + (value % 2)) * FRAC);
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> nearbyint(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> nearbyint(fixed<B, I, F, R> x) noexcept
 {
     // Rounding mode is assumed to be FE_TONEAREST
     constexpr auto FRAC = B(1) << F;
@@ -164,11 +164,11 @@ fixed<B, I, F> nearbyint(fixed<B, I, F> x) noexcept
     value /= FRAC / 2;
     value = (value / 2) + (value % 2);
     value -= (value % 2) * is_half;
-    return fixed<B, I, F>::from_raw_value(value * FRAC);
+    return fixed<B, I, F, R>::from_raw_value(value * FRAC);
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline fixed<B, I, F> rint(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline fixed<B, I, F, R> rint(fixed<B, I, F, R> x) noexcept
 {
     // Rounding mode is assumed to be FE_TONEAREST
     return nearbyint(x);
@@ -177,70 +177,70 @@ constexpr inline fixed<B, I, F> rint(fixed<B, I, F> x) noexcept
 //
 // Mathematical functions
 //
-template <typename B, typename I, unsigned int F>
-constexpr inline fixed<B, I, F> abs(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline fixed<B, I, F, R> abs(fixed<B, I, F, R> x) noexcept
 {
-    return (x >= fixed<B, I, F>{0}) ? x : -x;
+    return (x >= fixed<B, I, F, R>{0}) ? x : -x;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline fixed<B, I, F> fmod(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline fixed<B, I, F, R> fmod(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     return
         assert(y.raw_value() != 0),
-        fixed<B, I, F>::from_raw_value(x.raw_value() % y.raw_value());
+        fixed<B, I, F, R>::from_raw_value(x.raw_value() % y.raw_value());
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline fixed<B, I, F> remainder(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline fixed<B, I, F, R> remainder(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     return
         assert(y.raw_value() != 0),
         x - nearbyint(x / y) * y;
 }
 
-template <typename B, typename I, unsigned int F>
-inline fixed<B, I, F> remquo(fixed<B, I, F> x, fixed<B, I, F> y, int* quo) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+inline fixed<B, I, F, R> remquo(fixed<B, I, F, R> x, fixed<B, I, F, R> y, int* quo) noexcept
 {
     assert(y.raw_value() != 0);
     assert(quo != nullptr);
     *quo = x.raw_value() / y.raw_value();
-    return fixed<B, I, F>::from_raw_value(x.raw_value() % y.raw_value());
+    return fixed<B, I, F, R>::from_raw_value(x.raw_value() % y.raw_value());
 }
 
 //
 // Manipulation functions
 //
 
-template <typename B, typename I, unsigned int F, typename C, typename J, unsigned int G>
-constexpr inline fixed<B, I, F> copysign(fixed<B, I, F> x, fixed<C, J, G> y) noexcept
+template <typename B, typename I, unsigned int F, bool R, typename C, typename J, unsigned int G, bool S>
+constexpr inline fixed<B, I, F, R> copysign(fixed<B, I, F, R> x, fixed<C, J, G, S> y) noexcept
 {
     return
         x = abs(x),
-        (y >= fixed<C, J, G>{0}) ? x : -x;
+        (y >= fixed<C, J, G, S>{0}) ? x : -x;
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline fixed<B, I, F> nextafter(fixed<B, I, F> from, fixed<B, I, F> to) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline fixed<B, I, F, R> nextafter(fixed<B, I, F, R> from, fixed<B, I, F, R> to) noexcept
 {
     return from == to ? to :
-           to > from ? fixed<B, I, F>::from_raw_value(from.raw_value() + 1)
-                     : fixed<B, I, F>::from_raw_value(from.raw_value() - 1);
+           to > from ? fixed<B, I, F, R>::from_raw_value(from.raw_value() + 1)
+                     : fixed<B, I, F, R>::from_raw_value(from.raw_value() - 1);
 }
 
-template <typename B, typename I, unsigned int F>
-constexpr inline fixed<B, I, F> nexttoward(fixed<B, I, F> from, fixed<B, I, F> to) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+constexpr inline fixed<B, I, F, R> nexttoward(fixed<B, I, F, R> from, fixed<B, I, F, R> to) noexcept
 {
     return nextafter(from, to);
 }
 
-template <typename B, typename I, unsigned int F>
-inline fixed<B, I, F> modf(fixed<B, I, F> x, fixed<B, I, F>* iptr) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+inline fixed<B, I, F, R> modf(fixed<B, I, F, R> x, fixed<B, I, F, R>* iptr) noexcept
 {
     const auto raw = x.raw_value();
     constexpr auto FRAC = B{1} << F;
-    *iptr = fixed<B, I, F>::from_raw_value(raw / FRAC * FRAC);
-    return fixed<B, I, F>::from_raw_value(raw % FRAC);
+    *iptr = fixed<B, I, F, R>::from_raw_value(raw / FRAC * FRAC);
+    return fixed<B, I, F, R>::from_raw_value(raw % FRAC);
 }
 
 
@@ -248,10 +248,10 @@ inline fixed<B, I, F> modf(fixed<B, I, F> x, fixed<B, I, F>* iptr) noexcept
 // Power functions
 //
 
-template <typename B, typename I, unsigned int F, typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
-fixed<B, I, F> pow(fixed<B, I, F> base, T exp) noexcept
+template <typename B, typename I, unsigned int F, bool R, typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
+fixed<B, I, F, R> pow(fixed<B, I, F, R> base, T exp) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
 
     if (base == Fixed(0)) {
         assert(exp > 0);
@@ -282,10 +282,10 @@ fixed<B, I, F> pow(fixed<B, I, F> base, T exp) noexcept
     return result;
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> pow(fixed<B, I, F> base, fixed<B, I, F> exp) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> pow(fixed<B, I, F, R> base, fixed<B, I, F, R> exp) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
 
     if (base == Fixed(0)) {
         assert(exp > Fixed(0));
@@ -311,10 +311,10 @@ fixed<B, I, F> pow(fixed<B, I, F> base, fixed<B, I, F> exp) noexcept
     return exp2(log2(base) * exp);
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> exp(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> exp(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     if (x < Fixed(0)) {
         return 1 / exp(-x);
     }
@@ -332,10 +332,10 @@ fixed<B, I, F> exp(fixed<B, I, F> x) noexcept
     return pow(Fixed::e(), x_int) * (((((fA * x + fB) * x + fC) * x + fD) * x + fE) * x + fF);
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> exp2(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> exp2(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     if (x < Fixed(0)) {
         return 1 / exp2(-x);
     }
@@ -353,16 +353,16 @@ fixed<B, I, F> exp2(fixed<B, I, F> x) noexcept
     return Fixed(1 << x_int) * (((((fA * x + fB) * x + fC) * x + fD) * x + fE) * x + fF);
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> expm1(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> expm1(fixed<B, I, F, R> x) noexcept
 {
     return exp(x) - 1;
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> log2(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> log2(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     assert(x > Fixed(0));
 
     // Normalize input to the [1:2] domain
@@ -385,30 +385,30 @@ fixed<B, I, F> log2(fixed<B, I, F> x) noexcept
     return Fixed(highest - F) + (((((fA * x + fB) * x + fC) * x + fD) * x + fE) * x + fF);
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> log(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> log(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     return log2(x) / log2(Fixed::e());
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> log10(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> log10(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     return log2(x) / log2(Fixed(10));
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> log1p(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> log1p(fixed<B, I, F, R> x) noexcept
 {
     return log(1 + x);
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> cbrt(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> cbrt(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
 
     if (x == Fixed(0))
     {
@@ -457,10 +457,10 @@ fixed<B, I, F> cbrt(fixed<B, I, F> x) noexcept
     return Fixed::from_raw_value(static_cast<B>(res));
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> sqrt(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> sqrt(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
 
     assert(x >= Fixed(0));
     if (x == Fixed(0))
@@ -496,8 +496,8 @@ fixed<B, I, F> sqrt(fixed<B, I, F> x) noexcept
     return Fixed::from_raw_value(static_cast<B>(res));
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> hypot(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> hypot(fixed<B, I, F, R> x, fixed<B, I, F, R> y) noexcept
 {
     assert(x != 0 || y != 0);
     return sqrt(x*x + y*y);
@@ -507,13 +507,13 @@ fixed<B, I, F> hypot(fixed<B, I, F> x, fixed<B, I, F> y) noexcept
 // Trigonometry functions
 //
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> sin(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> sin(fixed<B, I, F, R> x) noexcept
 {
     // This sine uses a fifth-order curve-fitting approximation originally
     // described by Jasper Vijn on coranac.com which has a worst-case
     // relative error of 0.07% (over [-pi:pi]).
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
 
     // Turn x from [0..2*PI] domain into [0..4] domain
     x = fmod(x, Fixed::two_pi());
@@ -540,14 +540,14 @@ fixed<B, I, F> sin(fixed<B, I, F> x) noexcept
     return sign * x * (Fixed::pi() - x2*(Fixed::two_pi() - 5 - x2*(Fixed::pi() - 3)))/2;
 }
 
-template <typename B, typename I, unsigned int F>
-inline fixed<B, I, F> cos(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+inline fixed<B, I, F, R> cos(fixed<B, I, F, R> x) noexcept
 {
-    return sin(fixed<B, I, F>::half_pi() + x);
+    return sin(fixed<B, I, F, R>::half_pi() + x);
 }
 
-template <typename B, typename I, unsigned int F>
-inline fixed<B, I, F> tan(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+inline fixed<B, I, F, R> tan(fixed<B, I, F, R> x) noexcept
 {
     auto cx = cos(x);
 
@@ -561,10 +561,10 @@ inline fixed<B, I, F> tan(fixed<B, I, F> x) noexcept
 namespace detail {
 
 // Calculates atan(x) assuming that x is in the range [0,1]
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> atan_sanitized(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> atan_sanitized(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     assert(x >= Fixed(0) && x <= Fixed(1));
 
     constexpr auto fA = Fixed::template from_fixed_point<63>(  716203666280654660ll); //  0.0776509570923569
@@ -581,10 +581,10 @@ fixed<B, I, F> atan_sanitized(fixed<B, I, F> x) noexcept
 // If q = y/x and q > 1, atan(q) would calculate atan(1/q) as intermediate step
 // anyway. We can shortcut that here and avoid the loss of information, thus
 // improving the accuracy of atan(y/x) for very small x.
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> atan_div(fixed<B, I, F> y, fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> atan_div(fixed<B, I, F, R> y, fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     assert(x != Fixed(0));
 
     // Make sure y and x are positive.
@@ -610,10 +610,10 @@ fixed<B, I, F> atan_div(fixed<B, I, F> y, fixed<B, I, F> x) noexcept
 
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> atan(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> atan(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     if (x < Fixed(0))
     {
         return -atan(-x);
@@ -627,10 +627,10 @@ fixed<B, I, F> atan(fixed<B, I, F> x) noexcept
     return detail::atan_sanitized(x);
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> asin(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> asin(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     assert(x >= Fixed(-1) && x <= Fixed(+1));
 
     const auto yy = Fixed(1) - x * x;
@@ -641,10 +641,10 @@ fixed<B, I, F> asin(fixed<B, I, F> x) noexcept
     return detail::atan_div(x, sqrt(yy));
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> acos(fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> acos(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     assert(x >= Fixed(-1) && x <= Fixed(+1));
 
     if (x == Fixed(-1))
@@ -655,10 +655,10 @@ fixed<B, I, F> acos(fixed<B, I, F> x) noexcept
     return Fixed(2)*detail::atan_div(sqrt(yy), Fixed(1) + x);
 }
 
-template <typename B, typename I, unsigned int F>
-fixed<B, I, F> atan2(fixed<B, I, F> y, fixed<B, I, F> x) noexcept
+template <typename B, typename I, unsigned int F, bool R>
+fixed<B, I, F, R> atan2(fixed<B, I, F, R> y, fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     if (x == Fixed(0))
     {
         assert(y != Fixed(0));


### PR DESCRIPTION
Forgot to update the math and io template parameters for #48. With this change you should be able to use these routines with rounding disabled. 