### PR TITLE
Bugfix/cosinus-overflow

### DIFF
--- a/include/fpm/math.hpp
+++ b/include/fpm/math.hpp
@@ -543,7 +543,12 @@ fixed<B, I, F, R> sin(fixed<B, I, F, R> x) noexcept
 template <typename B, typename I, unsigned int F, bool R>
 inline fixed<B, I, F, R> cos(fixed<B, I, F, R> x) noexcept
 {
-    return sin(fixed<B, I, F, R>::half_pi() + x);
+    using Fixed = fixed<B, I, F>;
+    if (x > Fixed(0)) {  // Prevent an overflow due to the addition of π/2
+        return sin(x - (Fixed::two_pi() - Fixed::half_pi()));
+    } else {
+        return sin(Fixed::half_pi() + x);
+    }    
 }
 
 template <typename B, typename I, unsigned int F, bool R>

--- a/tests/trigonometry.cpp
+++ b/tests/trigonometry.cpp
@@ -17,6 +17,10 @@ TEST(trigonometry, sin)
     }
 }
 
+// Size of an array
+template<class T, size_t N>
+constexpr size_t size(T (&)[N]) { return N; }
+
 TEST(trigonometry, cos)
 {
     using P = fpm::fixed<std::int32_t, std::int64_t, 16>;
@@ -30,6 +34,19 @@ TEST(trigonometry, cos)
         auto cos_real = std::cos(flt_angle);
         auto cos_fixed = static_cast<double>(cos(P(flt_angle)));
         EXPECT_TRUE(HasMaximumError(cos_fixed, cos_real, MAX_ERROR_PERC));
+    }
+
+    // Boundary-value analysis
+    constexpr int32_t raw_values[] = {INT32_MIN, 2147380703, 2147380704, INT32_MAX};
+    for (int32_t i=0; i<size(raw_values); i++)
+    {
+        constexpr auto MAX_ERROR_PERC = 0.034;  // ⚠️ Maximum deviation over the value range of f_16_16 --- despite the cosine bugfix
+        P angle_fixed = P::from_raw_value(raw_values[i]);
+        auto angle_real = static_cast<double>(angle_fixed);
+        auto cos_fixed = static_cast<double>(cos(angle_fixed));
+        auto cos_real = std::cos(angle_real);
+        auto diff = std::abs(cos_fixed - cos_real);
+        EXPECT_TRUE(HasMaximumError(cos_fixed, cos_real, MAX_ERROR_PERC)) << "i=" << i << ", raw_value=" << raw_values[i] << ", error=" << std::abs(diff/cos_real)*100 << "%";
     }
 }
 
@@ -51,6 +68,19 @@ TEST(trigonometry, tan)
             auto tan_fixed = static_cast<double>(tan(P(flt_angle)));
             EXPECT_TRUE(HasMaximumError(tan_fixed, tan_real, MAX_ERROR_PERC));
         }
+    }
+    
+    // Boundary-value analysis
+    constexpr int32_t raw_values[] = {INT32_MIN, 2147380703, 2147380704, INT32_MAX};
+    for (int32_t i=0; i<size(raw_values); i++)
+    {
+        constexpr auto MAX_ERROR_PERC = 0.038;  // ⚠️ Maximum deviation over the value range of f_16_16 --- despite the cosine bugfix
+        P angle_fixed = P::from_raw_value(raw_values[i]);
+        auto angle_real = static_cast<double>(angle_fixed);
+        auto tan_fixed = static_cast<double>(tan(angle_fixed));
+        auto tan_real = std::tan(angle_real);
+        auto diff = std::abs(tan_fixed - tan_real);
+        EXPECT_TRUE(HasMaximumError(tan_fixed, tan_real, MAX_ERROR_PERC)) << "i=" << i << ", raw_value=" << raw_values[i] << ", error=" << std::abs(diff/tan_real)*100 << "%";
     }
 
 #ifndef NDEBUG


### PR DESCRIPTION
Hello Mike

Currently I am working on the trigonometric functions (sin,cos,tan) of fpm.
I am creating an optimized version that has (for FractionBits ≥ 16) smaller deviation , with presumably the same performance.

I noticed that the cosine function uses an addition:

```cpp
return sin(fixed<B, I, F, R>::half_pi() + x);
```

An overflow is not detected. Due to the overflow, wrong values are calculated in some cases. 
This could happen especially for data types with few digits before the decimal point (fixed_8_24...).
Therefore a suggestion for a bugfix:

```cpp
if (x > Fixed(0)) {  // Prevent an overflow due to the addition of π/2
        return sin(x - (Fixed::two_pi() - Fixed::half_pi()));
    } else {
        return sin(Fixed::half_pi() + x);
    }
```

I have adapted the test in trigonometry.cpp accordingly. 
It now also tests the boundary raw values (INT32_MIN, INT32_MAX) and a value that has a deviation of 200% due to the error (for fixed_16_16). See code part "// Boundary-value analysis"

Note: in this code part I have set an error limit of ``MAX_ERROR_PERC = 0.034'', because the cosine values have a larger error over the whole range of values than in the interval [-π ... +π]. The same applies to tan(x).