### PR TITLE
Add option to disable explicit conversions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,13 @@ You must still guard against underflow and overflow, though.
 `fpm::fixed<A, B, C>` can be constructed from an `fpm::fixed<D, E, F>` via explicit construction. This allows for conversion between fixed-point numbers of differing precision and range.
 Depending on the respective underlying types and number of fraction bits, this conversion may throw away high bits in the integral or low bits in the fraction.
 
+Explicit conversions can be disabled by defining FPM_NO_EXPLICIT before including `fixed.hpp`, as so:
+
+```c++
+#define FPM_NO_EXPLICIT
+#include <fpm/fixed.hpp>
+```
+
 ## Printing and reading fixed-point numbers
 The `<fpm/ios.hpp>` header provides streaming operators. Simply stream an expression of type `fpm::fixed` to or from a `std::ostream`.
 

--- a/include/fpm/fixed.hpp
+++ b/include/fpm/fixed.hpp
@@ -8,6 +8,12 @@
 #include <limits>
 #include <type_traits>
 
+#ifdef FPM_NO_EXPLICIT
+#   define FPM_EXPLICIT
+#else
+#   define FPM_EXPLICIT explicit
+#endif
+
 namespace fpm
 {
 
@@ -38,14 +44,14 @@ public:
     // Converts an integral number to the fixed-point type.
     // Like static_cast, this truncates bits that don't fit.
     template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
-    constexpr inline explicit fixed(T val) noexcept
+    constexpr inline FPM_EXPLICIT fixed(T val) noexcept
         : m_value(static_cast<BaseType>(val * FRACTION_MULT))
     {}
 
     // Converts an floating-point number to the fixed-point type.
     // Like static_cast, this truncates bits that don't fit.
     template <typename T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
-    constexpr inline explicit fixed(T val) noexcept
+    constexpr inline FPM_EXPLICIT fixed(T val) noexcept
         : m_value(static_cast<BaseType>((EnableRounding) ?
 		       (val >= 0.0) ? (val * FRACTION_MULT + T{0.5}) : (val * FRACTION_MULT - T{0.5})
 		      : (val * FRACTION_MULT)))
@@ -54,20 +60,20 @@ public:
     // Constructs from another fixed-point type with possibly different underlying representation.
     // Like static_cast, this truncates bits that don't fit.
     template <typename B, typename I, unsigned int F, bool R>
-    constexpr inline explicit fixed(fixed<B,I,F,R> val) noexcept
+    constexpr inline FPM_EXPLICIT fixed(fixed<B,I,F,R> val) noexcept
         : m_value(from_fixed_point<F>(val.raw_value()).raw_value())
     {}
 
-    // Explicit conversion to a floating-point type
+    // Conversion to a floating-point type
     template <typename T, typename std::enable_if<std::is_floating_point<T>::value>::type* = nullptr>
-    constexpr inline explicit operator T() const noexcept
+    constexpr inline FPM_EXPLICIT operator T() const noexcept
     {
         return static_cast<T>(m_value) / FRACTION_MULT;
     }
 
-    // Explicit conversion to an integral type
+    // Conversion to an integral type
     template <typename T, typename std::enable_if<std::is_integral<T>::value>::type* = nullptr>
-    constexpr inline explicit operator T() const noexcept
+    constexpr inline FPM_EXPLICIT operator T() const noexcept
     {
         return static_cast<T>(m_value / FRACTION_MULT);
     }


### PR DESCRIPTION
I thought it would be best to allow users to choose whether or not they want explicit conversions, so I added FPM_NO_EXPLICIT to disable explicit conversions. Explicit conversions are on by default, though.