### PR TITLE
fix: cosine won't compile with rounding disabled

### DIFF
--- a/include/fpm/math.hpp
+++ b/include/fpm/math.hpp
@@ -543,7 +543,7 @@ fixed<B, I, F, R> sin(fixed<B, I, F, R> x) noexcept
 template <typename B, typename I, unsigned int F, bool R>
 inline fixed<B, I, F, R> cos(fixed<B, I, F, R> x) noexcept
 {
-    using Fixed = fixed<B, I, F>;
+    using Fixed = fixed<B, I, F, R>;
     if (x > Fixed(0)) {  // Prevent an overflow due to the addition of π/2
         return sin(x - (Fixed::two_pi() - Fixed::half_pi()));
     } else {


### PR DESCRIPTION
The alias in the cosine function doesn't respect the rounding parameter.
This PR fixes that.