### PR TITLE
Unary type trait `fpm::is_fixed`

### DIFF
--- a/include/fpm/fixed.hpp
+++ b/include/fpm/fixed.hpp
@@ -495,7 +495,7 @@ struct is_fixed : std::false_type {};
 template<typename BaseType, typename IntermediateType, unsigned int FractionBits, bool EnableRounding>
 struct is_fixed<fixed<BaseType, IntermediateType, FractionBits, EnableRounding>> : std::true_type {};
 
-#ifdef __cpp_lib_bool_constant
+#if  __cplusplus >= 201703L
 template<typename T>
 inline constexpr bool is_fixed_v = is_fixed<T>::value;
 #endif

--- a/include/fpm/fixed.hpp
+++ b/include/fpm/fixed.hpp
@@ -487,4 +487,17 @@ constexpr bool numeric_limits<fpm::fixed<B,I,F,R>>::tinyness_before;
 
 }
 
+namespace fpm
+{
+template<typename T>
+struct is_fixed : std::false_type {};
+
+template<typename BaseType, typename IntermediateType, unsigned int FractionBits, bool EnableRounding>
+struct is_fixed<fixed<BaseType, IntermediateType, FractionBits, EnableRounding>> : std::true_type {};
+
+#ifdef __cpp_lib_bool_constant
+template<typename T>
+inline constexpr bool is_fixed_v = is_fixed<T>::value;
+#endif
+}
 #endif


### PR DESCRIPTION
I could not find any "unary type trait", similar to [`std::is_integral`](https://en.cppreference.com/w/cpp/types/is_integral) for `fpm::fixed<>` so I wrote it. There may be more that would be good to implement but this was just the one I needed.
`fpm::is_fixed_v` is behind `#ifdef` as it requires C++17

I hope this is the correct approach and naming (matches `std` better than `fpm::is_fixed_number`). I've placed it at the end of `fixed.hpp` as I did not want to mess any of your formatting or layout.

I recommend checking [`<type_traits>`](https://en.cppreference.com/w/cpp/header/type_traits) as there may be some official one you may want to implement (I don't have enough experience in those but [`std::is_arithmetic`](https://en.cppreference.com/w/cpp/types/is_arithmetic) seems like one of those).