### PR TITLE
Add basic `<format>` formatter (C++20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ add_executable(fpm-test20
   #tests/power.cpp
   #tests/trigonometry.cpp
   tests/formatting.cpp
+  tests/formatting_wchar.cpp
 )
 set_target_properties(fpm-test20 PROPERTIES CXX_STANDARD 20)
 target_link_libraries(fpm-test20 PRIVATE fpm gtest_main)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,27 @@ set_target_properties(fpm-test PROPERTIES CXX_STANDARD 11)
 target_link_libraries(fpm-test PRIVATE fpm gtest_main)
 gtest_add_tests(TARGET fpm-test)
 
+add_executable(fpm-test20
+  #tests/arithmetic.cpp
+  #tests/arithmetic_int.cpp
+  #tests/basic_math.cpp
+  #tests/constants.cpp
+  #tests/conversion.cpp
+  #tests/classification.cpp
+  #tests/customizations.cpp
+  #tests/detail.cpp
+  #tests/input.cpp
+  #tests/manip.cpp
+  #tests/nearest.cpp
+  #tests/output.cpp
+  #tests/power.cpp
+  #tests/trigonometry.cpp
+  tests/formatting.cpp
+)
+set_target_properties(fpm-test20 PROPERTIES CXX_STANDARD 20)
+target_link_libraries(fpm-test20 PRIVATE fpm gtest_main)
+gtest_add_tests(TARGET fpm-test20 TEST_SUFFIX .cpp20)
+
 endif()
 
 #

--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -737,9 +737,12 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
 
 }
 
+#if __cplusplus >= 202002L
+#   include <version>
+#endif
 #ifdef __cpp_lib_format
-#include <format>
-#include <sstream>
+#   include <format>
+#   include <sstream>
 template<typename CharT, typename B, typename I, unsigned int F, bool R>
 struct formatter<fpm::fixed<B, I, F, R>, CharT>
 {

--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -744,7 +744,7 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
 #   include <format>
 #   include <sstream>
 template<typename CharT, typename B, typename I, unsigned int F, bool R>
-struct formatter<fpm::fixed<B, I, F, R>, CharT>
+struct std::formatter<fpm::fixed<B, I, F, R>, CharT>
 {
     bool showpos = false;
 

--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -740,8 +740,8 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
 #ifdef __cpp_lib_format
 #include <format>
 #include <sstream>
-template<typename B, typename I, unsigned int F, bool R>
-struct formatter<fpm::fixed<B, I, F, R>, char>
+template<typename CharT, typename B, typename I, unsigned int F, bool R>
+struct formatter<fpm::fixed<B, I, F, R>, CharT>
 {
     bool showpos = false;
 
@@ -764,7 +764,7 @@ struct formatter<fpm::fixed<B, I, F, R>, char>
     template<typename FormatContext>
     typename FormatContext::iterator format(const fpm::fixed<B, I, F, R>& value, FormatContext& ctx) const
     {
-        std::ostringstream out;
+        std::basic_ostringstream<CharT> out;
         if(showpos)
             out << std::showpos;
         out << value;

--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -737,4 +737,41 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
 
 }
 
+#ifdef __cpp_lib_format
+#include <format>
+#include <sstream>
+template<typename B, typename I, unsigned int F, bool R>
+struct formatter<fpm::fixed<B, I, F, R>, char>
+{
+    bool showpos = false;
+
+    template<class ParseContext>
+    constexpr typename ParseContext::iterator parse(ParseContext& ctx)
+    {
+        auto it = ctx.begin();
+        if(it != ctx.end() && *it == '+')
+        {
+            showpos = true;
+            ++it;
+        }
+        if(it != ctx.end() && *it != '}')
+        {
+            throw std::format_error("Invalid format");
+        }
+        return it;
+    }
+
+    template<typename FormatContext>
+    typename FormatContext::iterator format(const fpm::fixed<B, I, F, R>& value, FormatContext& ctx) const
+    {
+        std::ostringstream out;
+        if(showpos)
+            out << std::showpos;
+        out << value;
+
+        return std::ranges::copy(std::move(out).str(), ctx.out()).out;
+    }
+};
+#endif
+
 #endif

--- a/include/fpm/ios.hpp
+++ b/include/fpm/ios.hpp
@@ -743,6 +743,7 @@ std::basic_istream<CharT, Traits>& operator>>(std::basic_istream<CharT, Traits>&
 #       include <format>
 #       include <sstream>
 #       include <string_view>
+#       include <iomanip>
 template<typename CharT, typename B, typename I, unsigned int F, bool R>
 struct std::formatter<fpm::fixed<B, I, F, R>, CharT>
 {
@@ -962,7 +963,7 @@ struct std::formatter<fpm::fixed<B, I, F, R>, CharT>
                 throw std::format_error("Invalid sign behaviour");
         }
         if(precision != static_cast<std::size_t>(-1))
-            out << setprecision(precision);
+            out << std::setprecision(precision);
         if(type != FormatType::Default)
         {
             // Format type itself

--- a/tests/formatting.cpp
+++ b/tests/formatting.cpp
@@ -1,5 +1,3 @@
-#include <numbers>
-
 #include "common.hpp"
 #include <fpm/ios.hpp>
 
@@ -7,6 +5,7 @@
 #   include <version>
 #   ifdef __cpp_lib_format
 #       include <format>
+#       include <numbers>
 
 template <typename B, typename I, unsigned int F, bool R>
 inline void ExpectFormat(

--- a/tests/formatting.cpp
+++ b/tests/formatting.cpp
@@ -1,3 +1,5 @@
+#include <numbers>
+
 #include "common.hpp"
 #include <fpm/ios.hpp>
 
@@ -6,7 +8,13 @@
 #   ifdef __cpp_lib_format
 #       include <format>
 
-inline void ExpectFormat(const std::string_view format, const fpm::fixed_16_16 valFixed, const double valDouble, const std::string& expectedValue)
+template <typename B, typename I, unsigned int F, bool R>
+inline void ExpectFormat(
+    const std::string_view format,
+    const fpm::fixed<B, I, F, R> valFixed,
+    const double valDouble,
+    const std::string& expectedValue
+)
 {
     const auto resFixed = std::vformat(format, std::make_format_args(valFixed));
     const auto resDouble = std::vformat(format, std::make_format_args(valDouble));
@@ -43,34 +51,6 @@ TEST(formatting, basic)
     EXPECT_EQ(std::format("{:+}", fpm::fixed_16_16{123.0625}), std::string("+123.062"));
 }
 
-TEST(formatting, basic_wchar)
-{
-    EXPECT_EQ(std::format(L"{}",    fpm::fixed_16_16{0}), std::wstring(L"0"));
-    EXPECT_EQ(std::format(L"{0}",   fpm::fixed_16_16{0}), std::wstring(L"0"));
-    EXPECT_EQ(std::format(L"{:+}",  fpm::fixed_16_16{0}), std::wstring(L"+0"));
-    EXPECT_EQ(std::format(L"{0:+}", fpm::fixed_16_16{0}), std::wstring(L"+0"));
-
-    EXPECT_EQ(std::format(L"{}",    fpm::fixed_16_16{1}), std::wstring(L"1"));
-    EXPECT_EQ(std::format(L"{0}",   fpm::fixed_16_16{1}), std::wstring(L"1"));
-    EXPECT_EQ(std::format(L"{:+}",  fpm::fixed_16_16{1}), std::wstring(L"+1"));
-    EXPECT_EQ(std::format(L"{0:+}", fpm::fixed_16_16{1}), std::wstring(L"+1"));
-
-    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{42}), std::wstring(L"42"));
-    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{42}), std::wstring(L"+42"));
-
-    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123}), std::wstring(L"123"));
-    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123}), std::wstring(L"+123"));
-
-    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.25}), std::wstring(L"123.25"));
-    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.25}), std::wstring(L"+123.25"));
-
-    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.125}), std::wstring(L"123.125"));
-    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.125}), std::wstring(L"+123.125"));
-
-    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.0625}), std::wstring(L"123.062"));
-    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.0625}), std::wstring(L"+123.062"));
-}
-
 TEST(formatting, width)
 {
     EXPECT_EQ(std::format("{:0}", fpm::fixed_16_16{0}), std::string("0"));
@@ -81,6 +61,16 @@ TEST(formatting, width)
     EXPECT_EQ(std::format("{:5}", fpm::fixed_16_16{0}), std::string("    0"));
     EXPECT_EQ(std::format("{:6}", fpm::fixed_16_16{0}), std::string("     0"));
 }
+
+/*TEST(formatting, width_nested)
+{
+    for(int precision = 0; precision < 10; precision++)
+    {
+        const std::string strFixed  = std::format("{:{}}", fpm::fixed_16_16{0}, precision);
+        const std::string strDouble = std::format("{:{}}", 0.0, precision);
+        EXPECT_EQ(strFixed, strDouble);
+    }
+}*/
 
 TEST(formatting, fill_and_align)
 {
@@ -170,6 +160,105 @@ TEST(formatting, zero_padding)
 
     ExpectFormat("{:<06}", fpm::fixed_16_16{ 1},  1.0, "1     ");
     ExpectFormat("{:<06}", fpm::fixed_16_16{-1}, -1.0, "-1    ");
+}
+
+TEST(formatting, precision)
+{
+    const double dblValue = 2.015625;
+    const auto fpmValue = fpm::fixed_16_16(2.015625);
+
+    ExpectFormat("{:10f}",   fpmValue, dblValue, "  2.015625");
+    ExpectFormat("{:.5f}",   fpmValue, dblValue, "2.01562");
+    ExpectFormat("{:10.5f}", fpmValue, dblValue, "   2.01562");
+    ExpectFormat("{:10.6f}", fpmValue, dblValue, "  2.015625");
+    ExpectFormat("{:10.3f}", fpmValue, dblValue, "     2.016");
+    ExpectFormat("{:10.2f}", fpmValue, dblValue, "      2.02");
+}
+
+TEST(formatting, precision_pi)
+{
+    const double dblValue = std::numbers::pi_v<double>;
+    const auto fpmValue = fpm::fixed_8_24::pi(); // fpm::fixed_16_16 does not have enough precision
+
+    ExpectFormat("{:10f}",   fpmValue, dblValue, "  3.141593");
+    ExpectFormat("{:.5f}",   fpmValue, dblValue, "3.14159");
+
+    ExpectFormat("{:10.6f}", fpmValue, dblValue, "  3.141593");
+    ExpectFormat("{:10.5f}", fpmValue, dblValue, "   3.14159");
+    ExpectFormat("{:10.4f}", fpmValue, dblValue, "    3.1416");
+    ExpectFormat("{:10.3f}", fpmValue, dblValue, "     3.142");
+    ExpectFormat("{:10.2f}", fpmValue, dblValue, "      3.14");
+    ExpectFormat("{:10.1f}", fpmValue, dblValue, "       3.1");
+    ExpectFormat("{:10.0f}", fpmValue, dblValue, "         3");
+}
+
+/*TEST(formatting, precision_nested)
+{
+    const double dblValue = 2.015625;
+    const auto fpmValue = fpm::fixed_16_16(2.015625);
+
+    for(int precision = 0; precision < 10; precision++)
+    {
+        const std::string strFixed  = std::format("{:2.{}f}", fpmValue, precision);
+        const std::string strDouble = std::format("{:2.{}f}", dblValue, precision);
+        EXPECT_EQ(strFixed, strDouble);
+    }
+
+    for(int precision = 0; precision < 10; precision++)
+    {
+        for(int width = 0; width < precision + 2; width++)
+        {
+            const std::string strFixed  = std::format("{:{}.{}f}", fpmValue, width, precision);
+            const std::string strDouble = std::format("{:{}.{}f}", dblValue, width, precision);
+            EXPECT_EQ(strFixed, strDouble);
+        }
+
+        for(int width = 0; width < precision + 4; width++)
+        {
+            const std::string strFixed  = std::format("{:{}.{}f}", fpmValue, width, precision);
+            const std::string strDouble = std::format("{:{}.{}f}", dblValue, width, precision);
+            EXPECT_EQ(strFixed, strDouble);
+        }
+    }
+}*/
+
+TEST(formatting, types)
+{
+    const double dblValue = 2.015625;
+    const auto fpmValue = fpm::fixed_16_16(2.015625);
+
+    // Fixed
+    {
+        ExpectFormat("{:10.6f}", fpmValue, dblValue, "  2.015625");
+        ExpectFormat("{:10.6F}", fpmValue, dblValue, "  2.015625");
+
+        ExpectFormat("{:10.3f}", fpmValue, dblValue, "     2.016");
+        ExpectFormat("{:10.3F}", fpmValue, dblValue, "     2.016");
+    }
+    // Hex
+    {
+        // Implementation differs from `double`
+        // fpm:    " 0x1.02p+1"
+        // double: "1.020000P+1"
+        //ExpectFormat("{:10.6a}", fpmValue, dblValue, "1.020000p+1");
+        //ExpectFormat("{:10.6A}", fpmValue, dblValue, "1.020000P+1");
+    }
+    // Scientific
+    {
+        ExpectFormat("{:10.6e}", fpmValue, dblValue, "2.015625e+00");
+        ExpectFormat("{:10.6E}", fpmValue, dblValue, "2.015625E+00");
+
+        ExpectFormat("{:10.3e}", fpmValue, dblValue, " 2.016e+00");
+        ExpectFormat("{:10.3E}", fpmValue, dblValue, " 2.016E+00");
+    }
+    // General
+    {
+        ExpectFormat("{:10.6g}", fpmValue, dblValue, "   2.01562");
+        ExpectFormat("{:10.6G}", fpmValue, dblValue, "   2.01562");
+
+        ExpectFormat("{:10.3g}", fpmValue, dblValue, "      2.02");
+        ExpectFormat("{:10.3G}", fpmValue, dblValue, "      2.02");
+    }
 }
 
 #endif

--- a/tests/formatting.cpp
+++ b/tests/formatting.cpp
@@ -1,0 +1,176 @@
+#include "common.hpp"
+#include <fpm/ios.hpp>
+
+#if __cplusplus >= 202002L
+#   include <version>
+#   ifdef __cpp_lib_format
+#       include <format>
+
+inline void ExpectFormat(const std::string_view format, const fpm::fixed_16_16 valFixed, const double valDouble, const std::string& expectedValue)
+{
+    const auto resFixed = std::vformat(format, std::make_format_args(valFixed));
+    const auto resDouble = std::vformat(format, std::make_format_args(valDouble));
+    EXPECT_EQ(resFixed, expectedValue);
+    EXPECT_EQ(resDouble, expectedValue);
+    EXPECT_EQ(resFixed, resDouble);
+}
+
+TEST(formatting, basic)
+{
+    EXPECT_EQ(std::format("{}",    fpm::fixed_16_16{0}), std::string("0"));
+    EXPECT_EQ(std::format("{0}",   fpm::fixed_16_16{0}), std::string("0"));
+    EXPECT_EQ(std::format("{:+}",  fpm::fixed_16_16{0}), std::string("+0"));
+    EXPECT_EQ(std::format("{0:+}", fpm::fixed_16_16{0}), std::string("+0"));
+
+    EXPECT_EQ(std::format("{}",    fpm::fixed_16_16{1}), std::string("1"));
+    EXPECT_EQ(std::format("{0}",   fpm::fixed_16_16{1}), std::string("1"));
+    EXPECT_EQ(std::format("{:+}",  fpm::fixed_16_16{1}), std::string("+1"));
+    EXPECT_EQ(std::format("{0:+}", fpm::fixed_16_16{1}), std::string("+1"));
+
+    EXPECT_EQ(std::format("{}",   fpm::fixed_16_16{42}), std::string("42"));
+    EXPECT_EQ(std::format("{:+}", fpm::fixed_16_16{42}), std::string("+42"));
+
+    EXPECT_EQ(std::format("{}",   fpm::fixed_16_16{123}), std::string("123"));
+    EXPECT_EQ(std::format("{:+}", fpm::fixed_16_16{123}), std::string("+123"));
+
+    EXPECT_EQ(std::format("{}",   fpm::fixed_16_16{123.25}), std::string("123.25"));
+    EXPECT_EQ(std::format("{:+}", fpm::fixed_16_16{123.25}), std::string("+123.25"));
+
+    EXPECT_EQ(std::format("{}",   fpm::fixed_16_16{123.125}), std::string("123.125"));
+    EXPECT_EQ(std::format("{:+}", fpm::fixed_16_16{123.125}), std::string("+123.125"));
+
+    EXPECT_EQ(std::format("{}",   fpm::fixed_16_16{123.0625}), std::string("123.062"));
+    EXPECT_EQ(std::format("{:+}", fpm::fixed_16_16{123.0625}), std::string("+123.062"));
+}
+
+TEST(formatting, basic_wchar)
+{
+    EXPECT_EQ(std::format(L"{}",    fpm::fixed_16_16{0}), std::wstring(L"0"));
+    EXPECT_EQ(std::format(L"{0}",   fpm::fixed_16_16{0}), std::wstring(L"0"));
+    EXPECT_EQ(std::format(L"{:+}",  fpm::fixed_16_16{0}), std::wstring(L"+0"));
+    EXPECT_EQ(std::format(L"{0:+}", fpm::fixed_16_16{0}), std::wstring(L"+0"));
+
+    EXPECT_EQ(std::format(L"{}",    fpm::fixed_16_16{1}), std::wstring(L"1"));
+    EXPECT_EQ(std::format(L"{0}",   fpm::fixed_16_16{1}), std::wstring(L"1"));
+    EXPECT_EQ(std::format(L"{:+}",  fpm::fixed_16_16{1}), std::wstring(L"+1"));
+    EXPECT_EQ(std::format(L"{0:+}", fpm::fixed_16_16{1}), std::wstring(L"+1"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{42}), std::wstring(L"42"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{42}), std::wstring(L"+42"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123}), std::wstring(L"123"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123}), std::wstring(L"+123"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.25}), std::wstring(L"123.25"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.25}), std::wstring(L"+123.25"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.125}), std::wstring(L"123.125"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.125}), std::wstring(L"+123.125"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.0625}), std::wstring(L"123.062"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.0625}), std::wstring(L"+123.062"));
+}
+
+TEST(formatting, width)
+{
+    EXPECT_EQ(std::format("{:0}", fpm::fixed_16_16{0}), std::string("0"));
+    EXPECT_EQ(std::format("{:1}", fpm::fixed_16_16{0}), std::string("0"));
+    EXPECT_EQ(std::format("{:2}", fpm::fixed_16_16{0}), std::string(" 0"));
+    EXPECT_EQ(std::format("{:3}", fpm::fixed_16_16{0}), std::string("  0"));
+    EXPECT_EQ(std::format("{:4}", fpm::fixed_16_16{0}), std::string("   0"));
+    EXPECT_EQ(std::format("{:5}", fpm::fixed_16_16{0}), std::string("    0"));
+    EXPECT_EQ(std::format("{:6}", fpm::fixed_16_16{0}), std::string("     0"));
+}
+
+TEST(formatting, fill_and_align)
+{
+    ExpectFormat("{:6}", fpm::fixed_16_16{  0},   0.0, "     0");
+    ExpectFormat("{:6}", fpm::fixed_16_16{  1},   1.0, "     1");
+    ExpectFormat("{:6}", fpm::fixed_16_16{ 42},  42.0, "    42");
+    ExpectFormat("{:6}", fpm::fixed_16_16{123}, 123.0, "   123");
+    ExpectFormat("{:6}", fpm::fixed_16_16{ -1},  -1.0, "    -1");
+    ExpectFormat("{:6}", fpm::fixed_16_16{-42}, -42.0, "   -42");
+
+    ExpectFormat("{:*>6}", fpm::fixed_16_16{  0},   0.0, "*****0");
+    ExpectFormat("{:*>6}", fpm::fixed_16_16{  1},   1.0, "*****1");
+    ExpectFormat("{:*>6}", fpm::fixed_16_16{ 42},  42.0, "****42");
+    ExpectFormat("{:*>6}", fpm::fixed_16_16{123}, 123.0, "***123");
+    ExpectFormat("{:*>6}", fpm::fixed_16_16{ -1},  -1.0, "****-1");
+    ExpectFormat("{:*>6}", fpm::fixed_16_16{-42}, -42.0, "***-42");
+
+    ExpectFormat("{:x>6}", fpm::fixed_16_16{  0},   0.0, "xxxxx0");
+    ExpectFormat("{:x>6}", fpm::fixed_16_16{  1},   1.0, "xxxxx1");
+    ExpectFormat("{:x>6}", fpm::fixed_16_16{ 42},  42.0, "xxxx42");
+    ExpectFormat("{:x>6}", fpm::fixed_16_16{123}, 123.0, "xxx123");
+    ExpectFormat("{:x>6}", fpm::fixed_16_16{ -1},  -1.0, "xxxx-1");
+    ExpectFormat("{:x>6}", fpm::fixed_16_16{-42}, -42.0, "xxx-42");
+
+    ExpectFormat("{:+>6}", fpm::fixed_16_16{  0},   0.0, "+++++0");
+    ExpectFormat("{:+>6}", fpm::fixed_16_16{  1},   1.0, "+++++1");
+    ExpectFormat("{:+>6}", fpm::fixed_16_16{ 42},  42.0, "++++42");
+    ExpectFormat("{:+>6}", fpm::fixed_16_16{123}, 123.0, "+++123");
+    ExpectFormat("{:+>6}", fpm::fixed_16_16{ -1},  -1.0, "++++-1");
+    ExpectFormat("{:+>6}", fpm::fixed_16_16{-42}, -42.0, "+++-42");
+
+    ExpectFormat("{:>>6}", fpm::fixed_16_16{  0},   0.0, ">>>>>0");
+    ExpectFormat("{:>>6}", fpm::fixed_16_16{  1},   1.0, ">>>>>1");
+    ExpectFormat("{:>>6}", fpm::fixed_16_16{ 42},  42.0, ">>>>42");
+    ExpectFormat("{:>>6}", fpm::fixed_16_16{123}, 123.0, ">>>123");
+    ExpectFormat("{:>>6}", fpm::fixed_16_16{ -1},  -1.0, ">>>>-1");
+    ExpectFormat("{:>>6}", fpm::fixed_16_16{-42}, -42.0, ">>>-42");
+
+    ExpectFormat("{:0>6}", fpm::fixed_16_16{  0},   0.0, "000000");
+    ExpectFormat("{:0>6}", fpm::fixed_16_16{  1},   1.0, "000001");
+    ExpectFormat("{:0>6}", fpm::fixed_16_16{ 42},  42.0, "000042");
+    ExpectFormat("{:0>6}", fpm::fixed_16_16{123}, 123.0, "000123");
+    ExpectFormat("{:0>6}", fpm::fixed_16_16{ -1},  -1.0, "0000-1");
+    ExpectFormat("{:0>6}", fpm::fixed_16_16{-42}, -42.0, "000-42");
+
+    ExpectFormat("{:<6}", fpm::fixed_16_16{  0},   0.0, "0     ");
+    ExpectFormat("{:<6}", fpm::fixed_16_16{  1},   1.0, "1     ");
+    ExpectFormat("{:<6}", fpm::fixed_16_16{ 42},  42.0, "42    ");
+    ExpectFormat("{:<6}", fpm::fixed_16_16{123}, 123.0, "123   ");
+    ExpectFormat("{:<6}", fpm::fixed_16_16{ -1},  -1.0, "-1    ");
+    ExpectFormat("{:<6}", fpm::fixed_16_16{-42}, -42.0, "-42   ");
+
+    ExpectFormat("{:^6}", fpm::fixed_16_16{  0},   0.0, "  0   ");
+    ExpectFormat("{:^6}", fpm::fixed_16_16{  1},   1.0, "  1   ");
+    ExpectFormat("{:^6}", fpm::fixed_16_16{ 42},  42.0, "  42  ");
+    ExpectFormat("{:^6}", fpm::fixed_16_16{123}, 123.0, " 123  ");
+    ExpectFormat("{:^6}", fpm::fixed_16_16{ -1},  -1.0, "  -1  ");
+    ExpectFormat("{:^6}", fpm::fixed_16_16{-42}, -42.0, " -42  ");
+
+    ExpectFormat("{:^2}", fpm::fixed_16_16{123}, 123.0, "123");
+    ExpectFormat("{:^2}", fpm::fixed_16_16{12345}, 12345.0, "12345");
+    ExpectFormat("{:^4}", fpm::fixed_16_16{12345}, 12345.0, "12345");
+}
+
+TEST(formatting, sign)
+{
+    ExpectFormat("{0:},{0:+},{0:-},{0: }", fpm::fixed_16_16{ 1},  1.0, "1,+1,1, 1");
+    ExpectFormat("{0:},{0:+},{0:-},{0: }", fpm::fixed_16_16{-1}, -1.0, "-1,-1,-1,-1");
+}
+
+TEST(formatting, zero_padding)
+{
+    ExpectFormat("{:02}", fpm::fixed_16_16{ 1},  1.0, "01");
+    ExpectFormat("{:02}", fpm::fixed_16_16{-1}, -1.0, "-1");
+
+    ExpectFormat("{:03}", fpm::fixed_16_16{ 1},  1.0, "001");
+    ExpectFormat("{:03}", fpm::fixed_16_16{-1}, -1.0, "-01");
+
+    ExpectFormat("{:04}", fpm::fixed_16_16{ 1},  1.0, "0001");
+    ExpectFormat("{:04}", fpm::fixed_16_16{-1}, -1.0, "-001");
+
+    ExpectFormat("{:06}", fpm::fixed_16_16{ 1},  1.0, "000001");
+    ExpectFormat("{:06}", fpm::fixed_16_16{-1}, -1.0, "-00001");
+
+    ExpectFormat("{:<02}", fpm::fixed_16_16{ 1},  1.0, "1 ");
+    ExpectFormat("{:<02}", fpm::fixed_16_16{-1}, -1.0, "-1");
+
+    ExpectFormat("{:<06}", fpm::fixed_16_16{ 1},  1.0, "1     ");
+    ExpectFormat("{:<06}", fpm::fixed_16_16{-1}, -1.0, "-1    ");
+}
+
+#endif
+#endif

--- a/tests/formatting_wchar.cpp
+++ b/tests/formatting_wchar.cpp
@@ -1,5 +1,3 @@
-#include <numbers>
-
 #include "common.hpp"
 #include <fpm/ios.hpp>
 
@@ -7,6 +5,7 @@
 #   include <version>
 #   ifdef __cpp_lib_format
 #       include <format>
+#       include <numbers>
 
 template <typename B, typename I, unsigned int F, bool R>
 inline void ExpectFormat(

--- a/tests/formatting_wchar.cpp
+++ b/tests/formatting_wchar.cpp
@@ -1,0 +1,264 @@
+#include <numbers>
+
+#include "common.hpp"
+#include <fpm/ios.hpp>
+
+#if __cplusplus >= 202002L
+#   include <version>
+#   ifdef __cpp_lib_format
+#       include <format>
+
+template <typename B, typename I, unsigned int F, bool R>
+inline void ExpectFormat(
+    const std::wstring_view format,
+    const fpm::fixed<B, I, F, R> valFixed,
+    const double valDouble,
+    const std::wstring& expectedValue
+)
+{
+    const auto resFixed = std::vformat(format, std::make_wformat_args(valFixed));
+    const auto resDouble = std::vformat(format, std::make_wformat_args(valDouble));
+    EXPECT_EQ(resFixed, expectedValue);
+    EXPECT_EQ(resDouble, expectedValue);
+    EXPECT_EQ(resFixed, resDouble);
+}
+
+TEST(formatting_wchar, basic)
+{
+    EXPECT_EQ(std::format(L"{}",    fpm::fixed_16_16{0}), std::wstring(L"0"));
+    EXPECT_EQ(std::format(L"{0}",   fpm::fixed_16_16{0}), std::wstring(L"0"));
+    EXPECT_EQ(std::format(L"{:+}",  fpm::fixed_16_16{0}), std::wstring(L"+0"));
+    EXPECT_EQ(std::format(L"{0:+}", fpm::fixed_16_16{0}), std::wstring(L"+0"));
+
+    EXPECT_EQ(std::format(L"{}",    fpm::fixed_16_16{1}), std::wstring(L"1"));
+    EXPECT_EQ(std::format(L"{0}",   fpm::fixed_16_16{1}), std::wstring(L"1"));
+    EXPECT_EQ(std::format(L"{:+}",  fpm::fixed_16_16{1}), std::wstring(L"+1"));
+    EXPECT_EQ(std::format(L"{0:+}", fpm::fixed_16_16{1}), std::wstring(L"+1"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{42}), std::wstring(L"42"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{42}), std::wstring(L"+42"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123}), std::wstring(L"123"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123}), std::wstring(L"+123"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.25}), std::wstring(L"123.25"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.25}), std::wstring(L"+123.25"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.125}), std::wstring(L"123.125"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.125}), std::wstring(L"+123.125"));
+
+    EXPECT_EQ(std::format(L"{}",   fpm::fixed_16_16{123.0625}), std::wstring(L"123.062"));
+    EXPECT_EQ(std::format(L"{:+}", fpm::fixed_16_16{123.0625}), std::wstring(L"+123.062"));
+}
+
+TEST(formatting_wchar, width)
+{
+    EXPECT_EQ(std::format(L"{:0}", fpm::fixed_16_16{0}), std::wstring(L"0"));
+    EXPECT_EQ(std::format(L"{:1}", fpm::fixed_16_16{0}), std::wstring(L"0"));
+    EXPECT_EQ(std::format(L"{:2}", fpm::fixed_16_16{0}), std::wstring(L" 0"));
+    EXPECT_EQ(std::format(L"{:3}", fpm::fixed_16_16{0}), std::wstring(L"  0"));
+    EXPECT_EQ(std::format(L"{:4}", fpm::fixed_16_16{0}), std::wstring(L"   0"));
+    EXPECT_EQ(std::format(L"{:5}", fpm::fixed_16_16{0}), std::wstring(L"    0"));
+    EXPECT_EQ(std::format(L"{:6}", fpm::fixed_16_16{0}), std::wstring(L"     0"));
+}
+
+/*TEST(formatting_wchar, width_nested)
+{
+    for(int precision = 0; precision < 10; precision++)
+    {
+        const std::wstring strFixed  = std::format(L"{:{}}", fpm::fixed_16_16{0}, precision);
+        const std::wstring strDouble = std::format(L"{:{}}", 0.0, precision);
+        EXPECT_EQ(strFixed, strDouble);
+    }
+}*/
+
+TEST(formatting_wchar, fill_and_align)
+{
+    ExpectFormat(L"{:6}", fpm::fixed_16_16{  0},   0.0, L"     0");
+    ExpectFormat(L"{:6}", fpm::fixed_16_16{  1},   1.0, L"     1");
+    ExpectFormat(L"{:6}", fpm::fixed_16_16{ 42},  42.0, L"    42");
+    ExpectFormat(L"{:6}", fpm::fixed_16_16{123}, 123.0, L"   123");
+    ExpectFormat(L"{:6}", fpm::fixed_16_16{ -1},  -1.0, L"    -1");
+    ExpectFormat(L"{:6}", fpm::fixed_16_16{-42}, -42.0, L"   -42");
+
+    ExpectFormat(L"{:*>6}", fpm::fixed_16_16{  0},   0.0, L"*****0");
+    ExpectFormat(L"{:*>6}", fpm::fixed_16_16{  1},   1.0, L"*****1");
+    ExpectFormat(L"{:*>6}", fpm::fixed_16_16{ 42},  42.0, L"****42");
+    ExpectFormat(L"{:*>6}", fpm::fixed_16_16{123}, 123.0, L"***123");
+    ExpectFormat(L"{:*>6}", fpm::fixed_16_16{ -1},  -1.0, L"****-1");
+    ExpectFormat(L"{:*>6}", fpm::fixed_16_16{-42}, -42.0, L"***-42");
+
+    ExpectFormat(L"{:x>6}", fpm::fixed_16_16{  0},   0.0, L"xxxxx0");
+    ExpectFormat(L"{:x>6}", fpm::fixed_16_16{  1},   1.0, L"xxxxx1");
+    ExpectFormat(L"{:x>6}", fpm::fixed_16_16{ 42},  42.0, L"xxxx42");
+    ExpectFormat(L"{:x>6}", fpm::fixed_16_16{123}, 123.0, L"xxx123");
+    ExpectFormat(L"{:x>6}", fpm::fixed_16_16{ -1},  -1.0, L"xxxx-1");
+    ExpectFormat(L"{:x>6}", fpm::fixed_16_16{-42}, -42.0, L"xxx-42");
+
+    ExpectFormat(L"{:+>6}", fpm::fixed_16_16{  0},   0.0, L"+++++0");
+    ExpectFormat(L"{:+>6}", fpm::fixed_16_16{  1},   1.0, L"+++++1");
+    ExpectFormat(L"{:+>6}", fpm::fixed_16_16{ 42},  42.0, L"++++42");
+    ExpectFormat(L"{:+>6}", fpm::fixed_16_16{123}, 123.0, L"+++123");
+    ExpectFormat(L"{:+>6}", fpm::fixed_16_16{ -1},  -1.0, L"++++-1");
+    ExpectFormat(L"{:+>6}", fpm::fixed_16_16{-42}, -42.0, L"+++-42");
+
+    ExpectFormat(L"{:>>6}", fpm::fixed_16_16{  0},   0.0, L">>>>>0");
+    ExpectFormat(L"{:>>6}", fpm::fixed_16_16{  1},   1.0, L">>>>>1");
+    ExpectFormat(L"{:>>6}", fpm::fixed_16_16{ 42},  42.0, L">>>>42");
+    ExpectFormat(L"{:>>6}", fpm::fixed_16_16{123}, 123.0, L">>>123");
+    ExpectFormat(L"{:>>6}", fpm::fixed_16_16{ -1},  -1.0, L">>>>-1");
+    ExpectFormat(L"{:>>6}", fpm::fixed_16_16{-42}, -42.0, L">>>-42");
+
+    ExpectFormat(L"{:0>6}", fpm::fixed_16_16{  0},   0.0, L"000000");
+    ExpectFormat(L"{:0>6}", fpm::fixed_16_16{  1},   1.0, L"000001");
+    ExpectFormat(L"{:0>6}", fpm::fixed_16_16{ 42},  42.0, L"000042");
+    ExpectFormat(L"{:0>6}", fpm::fixed_16_16{123}, 123.0, L"000123");
+    ExpectFormat(L"{:0>6}", fpm::fixed_16_16{ -1},  -1.0, L"0000-1");
+    ExpectFormat(L"{:0>6}", fpm::fixed_16_16{-42}, -42.0, L"000-42");
+
+    ExpectFormat(L"{:<6}", fpm::fixed_16_16{  0},   0.0, L"0     ");
+    ExpectFormat(L"{:<6}", fpm::fixed_16_16{  1},   1.0, L"1     ");
+    ExpectFormat(L"{:<6}", fpm::fixed_16_16{ 42},  42.0, L"42    ");
+    ExpectFormat(L"{:<6}", fpm::fixed_16_16{123}, 123.0, L"123   ");
+    ExpectFormat(L"{:<6}", fpm::fixed_16_16{ -1},  -1.0, L"-1    ");
+    ExpectFormat(L"{:<6}", fpm::fixed_16_16{-42}, -42.0, L"-42   ");
+
+    ExpectFormat(L"{:^6}", fpm::fixed_16_16{  0},   0.0, L"  0   ");
+    ExpectFormat(L"{:^6}", fpm::fixed_16_16{  1},   1.0, L"  1   ");
+    ExpectFormat(L"{:^6}", fpm::fixed_16_16{ 42},  42.0, L"  42  ");
+    ExpectFormat(L"{:^6}", fpm::fixed_16_16{123}, 123.0, L" 123  ");
+    ExpectFormat(L"{:^6}", fpm::fixed_16_16{ -1},  -1.0, L"  -1  ");
+    ExpectFormat(L"{:^6}", fpm::fixed_16_16{-42}, -42.0, L" -42  ");
+
+    ExpectFormat(L"{:^2}", fpm::fixed_16_16{123}, 123.0, L"123");
+    ExpectFormat(L"{:^2}", fpm::fixed_16_16{12345}, 12345.0, L"12345");
+    ExpectFormat(L"{:^4}", fpm::fixed_16_16{12345}, 12345.0, L"12345");
+}
+
+TEST(formatting_wchar, sign)
+{
+    ExpectFormat(L"{0:},{0:+},{0:-},{0: }", fpm::fixed_16_16{ 1},  1.0, L"1,+1,1, 1");
+    ExpectFormat(L"{0:},{0:+},{0:-},{0: }", fpm::fixed_16_16{-1}, -1.0, L"-1,-1,-1,-1");
+}
+
+TEST(formatting_wchar, zero_padding)
+{
+    ExpectFormat(L"{:02}", fpm::fixed_16_16{ 1},  1.0, L"01");
+    ExpectFormat(L"{:02}", fpm::fixed_16_16{-1}, -1.0, L"-1");
+
+    ExpectFormat(L"{:03}", fpm::fixed_16_16{ 1},  1.0, L"001");
+    ExpectFormat(L"{:03}", fpm::fixed_16_16{-1}, -1.0, L"-01");
+
+    ExpectFormat(L"{:04}", fpm::fixed_16_16{ 1},  1.0, L"0001");
+    ExpectFormat(L"{:04}", fpm::fixed_16_16{-1}, -1.0, L"-001");
+
+    ExpectFormat(L"{:06}", fpm::fixed_16_16{ 1},  1.0, L"000001");
+    ExpectFormat(L"{:06}", fpm::fixed_16_16{-1}, -1.0, L"-00001");
+
+    ExpectFormat(L"{:<02}", fpm::fixed_16_16{ 1},  1.0, L"1 ");
+    ExpectFormat(L"{:<02}", fpm::fixed_16_16{-1}, -1.0, L"-1");
+
+    ExpectFormat(L"{:<06}", fpm::fixed_16_16{ 1},  1.0, L"1     ");
+    ExpectFormat(L"{:<06}", fpm::fixed_16_16{-1}, -1.0, L"-1    ");
+}
+
+TEST(formatting_wchar, precision)
+{
+    const double dblValue = 2.015625;
+    const auto fpmValue = fpm::fixed_16_16(2.015625);
+
+    ExpectFormat(L"{:10f}",   fpmValue, dblValue, L"  2.015625");
+    ExpectFormat(L"{:.5f}",   fpmValue, dblValue, L"2.01562");
+    ExpectFormat(L"{:10.5f}", fpmValue, dblValue, L"   2.01562");
+    ExpectFormat(L"{:10.6f}", fpmValue, dblValue, L"  2.015625");
+    ExpectFormat(L"{:10.3f}", fpmValue, dblValue, L"     2.016");
+    ExpectFormat(L"{:10.2f}", fpmValue, dblValue, L"      2.02");
+}
+TEST(formatting_wchar, precision_pi)
+{
+    const double dblValue = std::numbers::pi_v<double>;
+    const auto fpmValue = fpm::fixed_8_24::pi(); // fpm::fixed_16_16 does not have enough precision
+
+    ExpectFormat(L"{:10f}",   fpmValue, dblValue, L"  3.141593");
+    ExpectFormat(L"{:.5f}",   fpmValue, dblValue, L"3.14159");
+
+    ExpectFormat(L"{:10.6f}", fpmValue, dblValue, L"  3.141593");
+    ExpectFormat(L"{:10.5f}", fpmValue, dblValue, L"   3.14159");
+    ExpectFormat(L"{:10.4f}", fpmValue, dblValue, L"    3.1416");
+    ExpectFormat(L"{:10.3f}", fpmValue, dblValue, L"     3.142");
+    ExpectFormat(L"{:10.2f}", fpmValue, dblValue, L"      3.14");
+    ExpectFormat(L"{:10.1f}", fpmValue, dblValue, L"       3.1");
+    ExpectFormat(L"{:10.0f}", fpmValue, dblValue, L"         3");
+}
+
+/*TEST(formatting_wchar, precision_nested)
+{
+    const double dblValue = 2.015625;
+    const auto fpmValue = fpm::fixed_16_16(2.015625);
+
+    for(int precision = 0; precision < 10; precision++)
+    {
+        const std::wstring strFixed  = std::format(L"{:2.{}f}", fpmValue, precision);
+        const std::wstring strDouble = std::format(L"{:2.{}f}", dblValue, precision);
+        EXPECT_EQ(strFixed, strDouble);
+    }
+
+    for(int precision = 0; precision < 10; precision++)
+    {
+        for(int width = 0; width < precision + 2; width++)
+        {
+            const std::wstring strFixed  = std::format(L"{:{}.{}f}", fpmValue, width, precision);
+            const std::wstring strDouble = std::format(L"{:{}.{}f}", dblValue, width, precision);
+            EXPECT_EQ(strFixed, strDouble);
+        }
+
+        for(int width = 0; width < precision + 4; width++)
+        {
+            const std::string strFixed  = std::format(L"{:{}.{}f}", fpmValue, width, precision);
+            const std::string strDouble = std::format(L"{:{}.{}f}", dblValue, width, precision);
+            EXPECT_EQ(strFixed, strDouble);
+        }
+    }
+}*/
+
+TEST(formatting_wchar, types)
+{
+    const double dblValue = 2.015625;
+    const auto fpmValue = fpm::fixed_16_16(2.015625);
+
+    // Fixed
+    {
+        ExpectFormat(L"{:10.6f}", fpmValue, dblValue, L"  2.015625");
+        ExpectFormat(L"{:10.6F}", fpmValue, dblValue, L"  2.015625");
+
+        ExpectFormat(L"{:10.3f}", fpmValue, dblValue, L"     2.016");
+        ExpectFormat(L"{:10.3F}", fpmValue, dblValue, L"     2.016");
+    }
+    // Hex
+    {
+        // Implementation differs from `double`
+        // fpm:    " 0x1.02p+1"
+        // double: "1.020000P+1"
+        //ExpectFormat(L"{:10.6a}", fpmValue, dblValue, L"1.020000p+1");
+        //ExpectFormat(L"{:10.6A}", fpmValue, dblValue, L"1.020000P+1");
+    }
+    // Scientific
+    {
+        ExpectFormat(L"{:10.6e}", fpmValue, dblValue, L"2.015625e+00");
+        ExpectFormat(L"{:10.6E}", fpmValue, dblValue, L"2.015625E+00");
+
+        ExpectFormat(L"{:10.3e}", fpmValue, dblValue, L" 2.016e+00");
+        ExpectFormat(L"{:10.3E}", fpmValue, dblValue, L" 2.016E+00");
+    }
+    // General
+    {
+        ExpectFormat(L"{:10.6g}", fpmValue, dblValue, L"   2.01562");
+        ExpectFormat(L"{:10.6G}", fpmValue, dblValue, L"   2.01562");
+
+        ExpectFormat(L"{:10.3g}", fpmValue, dblValue, L"      2.02");
+        ExpectFormat(L"{:10.3G}", fpmValue, dblValue, L"      2.02");
+    }
+}
+
+#endif
+#endif


### PR DESCRIPTION
TD;DR: Enable [`std::format`](https://en.cppreference.com/w/cpp/utility/format/format) for `fpm::fixed` with minimum code.

---

I have been using [`std::format`](https://en.cppreference.com/w/cpp/utility/format/format) from [`<format>`](https://en.cppreference.com/w/cpp/header/format) (C++20) as it does not require you to specify the type, which I consider big upgrade from [`printf`](https://en.cppreference.com/w/cpp/io/c/fprintf). While fpm has stream operators in `ios.hpp`, you need to specialize [`std::formatter<,>`](https://en.cppreference.com/w/cpp/utility/format/formatter) to use your own type. I've implemented very simple one just to allow me to print it anywhere - the only option there is `+`, as `{0:+}` for first argument, to always include sign character (using [`std::showpos`](https://en.cppreference.com/w/cpp/io/manip/showpos)). It uses [`std::stringstream`](https://en.cppreference.com/w/cpp/io/basic_stringstream) to redirect the existing `<<` operator.

I understand that the `std::format` probably has more overhead than `printf` which may not sit well with people who want to use fixed-point numbers due to them being faster than floating-point numbers. But you are not required to ever call `std::format` if that is a problem (or not supported by your platform) and I consider the `std::format` quality-of-life addition.
The specialized formatter is behind [C++ feature test](https://en.cppreference.com/w/cpp/feature_test) ( `__cpp_lib_format` without version check as the `std::formatter` is there from the beginning, there is also `__cpp_lib_formatters` which is for C++23 additions).

Possible enhancements:
- More formatting options (like precision)
- Optimized conversion to string for the formatter (related to #2 )